### PR TITLE
Fixed broken/outdated speedtest urls

### DIFF
--- a/bench
+++ b/bench
@@ -107,22 +107,21 @@ speed_test() {
 }
 
 speed_result() {
-    speed_test 'http://speedtest.frankfurt.linode.com/100MB-frankfurt.bin' 'Frankfurt, Linode'
+    speed_test 'http://speedtest.frankfurt.linode.com/100MB-frankfurt.bin' 'Frankfurt, Linode (Akamai)'
     speed_test 'https://fra-de-ping.vultr.com/vultr.com.100MB.bin' 'Frankfurt, Vultr'
     speed_test 'http://speedtest.tele2.net/100MB.zip' 'Frankfurt, TELE2'
-    speed_test 'https://lg.combahton.net/100MB.test' 'Frankfurt, Combahton'
-    speed_test 'http://fsn.icmp.hetzner.com/100MB.bin' 'Falkenstein, Hetzner'
-    speed_test 'https://speed.hetzner.de/100MB.bin' 'Nuremberg, Hetzner'
-    speed_test 'http://hel.icmp.hetzner.com/100MB.bin' 'Helsinki, Hetzner'
-    speed_test 'http://ash.icmp.hetzner.com/100MB.bin' 'Ashburn, Hetzner'
-    speed_test 'http://speedtest-ams2.digitalocean.com/100mb.test' 'Amsterdam, Digitalocean'
+    speed_test 'https://lg.aurologic.com/100MB.test' 'Frankfurt, Aurologic'
+    speed_test 'https://fsn1-speed.hetzner.com/100MB.bin' 'Falkenstein, Hetzner'
+    speed_test 'https://nbg1-speed.hetzner.com/100MB.bin' 'Nuremberg, Hetzner'
+    speed_test 'https://hel1-speed.hetzner.com/100MB.bin' 'Helsinki, Hetzner'
+    speed_test 'https://ash-speed.hetzner.com/100MB.bin' 'Ashburn, Hetzner' 
     speed_test 'https://ams.lg.core-backbone.com/files/100MB.test' 'Amsterdam, Core-Backbone'
-    speed_test 'http://speedtest.london.linode.com/100MB-london.bin' 'London, Linode'
+    speed_test 'http://speedtest.london.linode.com/100MB-london.bin' 'London, Linode (Akamai)'
     speed_test 'https://par-fr-ping.vultr.com/vultr.com.100MB.bin' 'Paris, Vultr'
-    speed_test 'http://speedtest.newark.linode.com/100MB-newark.bin' 'Newark, Linode'
-    speed_test 'http://speedtest.fremont.linode.com/100MB-newark.bin' 'Fremont, Linode'
+    speed_test 'http://speedtest.newark.linode.com/100MB-newark.bin' 'Newark, Linode (Akamai)'
+    speed_test 'http://speedtest.fremont.linode.com/100MB-newark.bin' 'Fremont, Linode (Akamai)'
     speed_test 'https://tx-us-ping.vultr.com/vultr.com.100MB.bin' 'Texas, Vultr'
-    speed_test 'http://speedtest.singapore.linode.com/100MB-singapore.bin' 'Singapore, Linode'
+    speed_test 'http://speedtest.singapore.linode.com/100MB-singapore.bin' 'Singapore, Linode (Akamai)'
 }
 
 ping_test() {


### PR DESCRIPTION
Hello together,

During the last run of this script on my machine i found some outdated/defect urls for the speedtests.
I've updated them now.

__Short summary:__
- Unfortunately the DigitalOcean speedtest site in Amsterdam does not exist anymore
- The german company combahton has been rebranded to aurologic and therefore their speedtest url has also changed
- Linode has been acquired by Akamai and the speedtest requests are now answered by servers from the Akamai network.
- Hetzner has changed the url's for their speedtest sites

That's it. Have a nice day!